### PR TITLE
Early exit for $.event wrapping if handler not a func

### DIFF
--- a/src/raygun.tracekit.jquery.js
+++ b/src/raygun.tracekit.jquery.js
@@ -12,7 +12,7 @@
   var _oldEventAdd = $.event.add;
   $.event.add = function traceKitEventAdd(elem, types, handler, data, selector) {
     if (typeof handler !== 'function' && typeof handler.handler !== 'function') {
-      _oldEventAdd.call(this, elem, types, handler, data, selector);
+      return _oldEventAdd.call(this, elem, types, handler, data, selector);
     }
 
     var _handler;


### PR DESCRIPTION
don't wrap the handler if it's not a func.
